### PR TITLE
DEV-97: Add BE auth setup

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -1,0 +1,48 @@
+from rest_framework import permissions, serializers, views
+from drf_spectacular.utils import extend_schema
+from knox.auth import TokenAuthentication
+
+
+class DefaultErrorResponseSerializer(serializers.Serializer):
+    """Default format of response when raising most APIException classes"""
+
+    detail = serializers.CharField()
+
+
+def _extend_responses(f):
+    # see https://github.com/tfranzel/drf-spectacular/blob/master/drf_spectacular/utils.py
+    BaseSchema = getattr(f, "kwargs", {}).get("schema", None)
+    if BaseSchema:
+
+        class ExtendedSchema(BaseSchema):
+            def get_response_serializers(self):
+                d = super().get_response_serializers()
+                # let's not touch it if there's already some spec
+                if 401 not in d:
+                    d[401] = DefaultErrorResponseSerializer
+                return d
+
+        f.kwargs["schema"] = ExtendedSchema
+        return f
+    return extend_schema(responses={401: DefaultErrorResponseSerializer})(f)
+
+
+def extend_schema_auth_failed(cls):
+    """Decorator. You're probably looking for require_authentication."""
+    if not issubclass(cls, views.APIView):
+        raise ValueError(str(cls) + " is not a rest_framework.views.APIView")
+    for meth in views.APIView.http_method_names:
+        if hasattr(cls, meth):
+            setattr(cls, meth, _extend_responses(getattr(cls, meth)))
+    return cls
+
+
+def require_authentication(cls):
+    """Adds authentication to an APIView. Put it above @extend_schema_view"""
+    cls = extend_schema_auth_failed(cls)
+
+    class Decorator(cls):
+        authentication_classes = (TokenAuthentication,)
+        permission_classes = (permissions.IsAuthenticated,)
+
+    return Decorator

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+
+class SignUpRequestSerializer(serializers.Serializer):
+    email = serializers.CharField(max_length=255)
+    name = serializers.CharField(max_length=255)
+    password = serializers.CharField()
+    base_language = serializers.CharField(max_length=50)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from .views import SignUpView, LoginView, LogoutView, LogoutAllView
+
+urlpatterns = [
+    path("sign-up/", SignUpView.as_view(), name="sign-up"),
+    path("login/", LoginView.as_view(), name="login"),
+    path("logout/", LogoutView.as_view(), name="logout"),
+    path("logoutall/", LogoutAllView.as_view(), name="logoutall"),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -58,6 +58,8 @@ class SignUpView(views.APIView):
 
 @decorators.extend_schema_auth_failed
 class LoginView(knox.views.LoginView):
+    """Note that email is used as the username."""
+
     permission_classes = (permissions.AllowAny,)
     serializer_class = AuthTokenSerializer
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,105 @@
-from django.shortcuts import render
+from django.contrib.auth import login, get_user_model
+from rest_framework import (
+    exceptions,
+    permissions,
+    response,
+    serializers,
+    status,
+    views,
+)
+from rest_framework.authtoken.serializers import AuthTokenSerializer
+from rest_framework.settings import api_settings
+from drf_spectacular.utils import extend_schema, inline_serializer
+import knox.views
 
-# Create your views here.
+from . import models, decorators
+from .serializers import SignUpRequestSerializer
+
+
+class SignUpView(views.APIView):
+    serializer_class = SignUpRequestSerializer
+
+    @extend_schema(
+        responses={
+            200: inline_serializer(
+                "SignUpResponseSerializer",
+                fields={
+                    "success": serializers.BooleanField(),
+                    "message": serializers.CharField(required=False),
+                },
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        d = serializer.validated_data
+        UserManager = get_user_model().objects
+        if UserManager.all().filter(email=d["email"]).count() > 0:
+            return response.Response(
+                {"success": False, "message": "Email already in use."},
+                status=200,
+            )
+        user = UserManager.create_user(d["email"], d["password"])
+        user.name = d["name"]
+        profile = models.UserProfile(
+            auth_user=user,
+            default_settings={},
+            base_language=d["base_language"],
+        )
+        user.save()
+        profile.save()
+        return response.Response({"success": True}, status=200)
+
+
+# see https://jazzband.github.io/django-rest-knox/auth/#global-usage-on-all-views
+# I also added 401, just copy-pasting from them gives 400 on failed login
+
+
+@decorators.extend_schema_auth_failed
+class LoginView(knox.views.LoginView):
+    permission_classes = (permissions.AllowAny,)
+    serializer_class = AuthTokenSerializer
+
+    # see https://github.com/jazzband/django-rest-knox/blob/develop/knox/views.py
+    @extend_schema(
+        responses={
+            200: inline_serializer(
+                "LoginResponse",
+                fields={
+                    "expiry": serializers.CharField(),
+                    "token": serializers.CharField(),
+                },
+            )
+        },
+    )
+    def post(self, request, format=None):
+        try:
+            serializer = self.serializer_class(data=request.data)
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError as e:
+            # see https://github.com/encode/django-rest-framework/blob/master/rest_framework/authtoken/serializers.py
+            # also https://www.django-rest-framework.org/api-guide/exceptions/, in the first section
+            if api_settings.NON_FIELD_ERRORS_KEY in e.detail:
+                # should be able to do e.detail[key][0] right away, this is just for my sanity
+                for detail in e.detail[api_settings.NON_FIELD_ERRORS_KEY]:
+                    if detail.code == "authorization":
+                        raise exceptions.AuthenticationFailed(detail)
+            raise
+        user = serializer.validated_data["user"]
+        login(request, user)
+        return super(LoginView, self).post(request, format)
+
+
+@decorators.extend_schema_auth_failed
+class LogoutView(knox.views.LogoutView):
+    @extend_schema(request=None, responses={204: None})
+    def post(self, request, format=None):
+        return super(LogoutView, self).post(request, format)
+
+
+@decorators.extend_schema_auth_failed
+class LogoutAllView(knox.views.LogoutAllView):
+    @extend_schema(request=None, responses={204: None})
+    def post(self, request, format=None):
+        return super(LogoutAllView, self).post(request, format)

--- a/pera_be/settings.py
+++ b/pera_be/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "drf_spectacular",
     "rest_framework",
+    "knox",
 
     "accounts",
     "hello_world",
@@ -163,6 +164,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": ("knox.auth.TokenAuthentication",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 

--- a/pera_be/urls.py
+++ b/pera_be/urls.py
@@ -21,6 +21,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, Sp
 
 urlpatterns = [
     path("hello_world/", include("hello_world.urls")),
+    path("accounts/", include("accounts.urls")),
     path("speech-processing/", include("speech_processing.urls")),
     path("admin/", admin.site.urls),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ colorama==0.4.6
 Django==5.1.7
 django-authtools==2.0.1
 django-cors-headers==4.7.0
+django-rest-knox==5.0.2
 djangorestframework==3.15.2
 drf-spectacular==0.28.0
 gunicorn==23.0.0


### PR DESCRIPTION
Implemented using django-rest-knox. Added urls. Check docs for them on swagger. I also added a decorator, `require_authentication` (in `accounts/decorators.py`) that you can use on views that require authentication, which would simply involve adding an HTTP header of the form `Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b` (this is the default behavior of `knox.auth.TokenAuthentication`). The token is returned on login.