### PR TITLE
Upgrade Django to 5.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2025.1.31
 click==8.1.8
 colorama==0.4.6
 coverage==7.8.0
-Django==5.1.7
+Django==5.1.8
 django-authtools==2.0.1
 django-cors-headers==4.7.0
 django-rest-knox==5.0.2


### PR DESCRIPTION
Resolves [Dependabot alert #2](https://github.com/dcsil/pera-be/security/dependabot/2).